### PR TITLE
add new library: Netflux

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@
 * [p2p-graph](https://github.com/feross/p2p-graph): Real-time P2P network visualization with D3
 * [planktos](https://github.com/xuset/planktos): Serving websites over bittorrent
 * [dat](https://github.com/datproject/dat): Sync data across the distributed web
+* [Netflux](https://github.com/coast-team/netflux) - full mesh network of clients and/or servers.
 
 
 


### PR DESCRIPTION
This library is maintained by our team in [Loria](http://www.loria.fr/en/) laboratory. It powers a [collaborative peer-to-peer editor](https://coedit.re/) and we consider it stable and ready to be used.

Netflux is a universal/isomorphic JavaScript API for an easy creation and joining a fully mesh network. The API is simple and very familiar for WebSocket and WebRTC users. Netflux is unique in different terms:

* It may use both WebRTC's RTCDataChannel and WebSocket technologies together in order to establish a mesh network between browsers (Chrome & Firefox) and NodeJS servers.
* Two signaling mechanisms are implemented:
  * Very common in WebRTC world - WebSocket signaling server. 
  * Much less frequent - the network itself (uses other peers).
* Protocol Buffer is used as message protocol within Netlfux which minimizes message overhead, hence implies a better performance.